### PR TITLE
Add PEP 723 metadata so that Python scripts can be invoked with `uv run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ make build
 make test
 ```
 
-Requirements: C++20 (Clang 14+ or GCC 12+), CMake 3.20+, macOS 13+ for Metal GPU.
+Requirements: C++20 (Clang 14+ or GCC 12+), CMake 3.20+, [uv](https://docs.astral.sh/uv/) (for Python scripts), macOS 13+ for Metal GPU.
 
 ## Convert Weights
 
@@ -67,19 +67,18 @@ Requirements: C++20 (Clang 14+ or GCC 12+), CMake 3.20+, macOS 13+ for Metal GPU
 huggingface-cli download nvidia/parakeet-tdt_ctc-110m --include "*.nemo" --local-dir .
 
 # Convert to safetensors
-pip install safetensors torch
-python scripts/convert_nemo.py parakeet-tdt_ctc-110m.nemo -o model.safetensors
+uv run scripts/convert_nemo.py parakeet-tdt_ctc-110m.nemo -o model.safetensors
 ```
 
 The converter supports all model types: `110m-tdt-ctc` (default), `600m-tdt`, `eou-120m`, `nemotron-600m`, `sortformer`.
 
 ```bash
-python scripts/convert_nemo.py checkpoint.nemo -o model.safetensors --model 600m-tdt
+uv run scripts/convert_nemo.py checkpoint.nemo -o model.safetensors --model 600m-tdt
 ```
 
 Silero VAD weights:
 ```bash
-python scripts/convert_silero_vad.py -o silero_vad_v5.safetensors
+uv run scripts/convert_silero_vad.py -o silero_vad_v5.safetensors
 ```
 
 ## Examples

--- a/scripts/convert_nemo.py
+++ b/scripts/convert_nemo.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["torch", "safetensors", "packaging", "numpy"]
+# ///
 """Convert NeMo Parakeet checkpoints to safetensors for axiom.
 
 Supported models:

--- a/scripts/convert_silero_vad.py
+++ b/scripts/convert_silero_vad.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["torch", "safetensors"]
+# ///
 """Convert Silero VAD v5 model to safetensors for axiom.
 
 Downloads the model from torch.hub and extracts weights using the known

--- a/scripts/extract_vocab.py
+++ b/scripts/extract_vocab.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
 """Extract SentencePiece vocabulary from a NeMo archive.
 
 Usage:

--- a/scripts/pytorch_benchmark.py
+++ b/scripts/pytorch_benchmark.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["torch", "pyyaml", "nemo_toolkit[asr]"]
+# ///
 """Benchmark PyTorch/NeMo inference for comparison with parakeet.cpp."""
 import os
 import sys


### PR DESCRIPTION
The README advises using `pip` to install modules system-wide, this change allows the scripts to be invoked with `uv run` to automatically set up the environment with the necessary dependencies