### PR TITLE
Confidence Scores

### DIFF
--- a/include/parakeet/eou.hpp
+++ b/include/parakeet/eou.hpp
@@ -81,6 +81,8 @@ struct StreamingDecodeState {
     std::vector<LSTMState> lstm_states;
     Tensor last_token; // (1,) int32
     std::vector<int> tokens;
+    std::vector<TimestampedToken> timestamped_tokens;
+    int frame_offset = 0; // absolute frame position across chunks
     bool initialized = false;
 };
 
@@ -122,6 +124,11 @@ class StreamingTranscriber {
 
     // Get full transcription so far.
     std::string get_text() const;
+
+    // Get accumulated timestamped tokens across all chunks.
+    const std::vector<TimestampedToken> &get_timestamped_tokens() const {
+        return decode_state_.timestamped_tokens;
+    }
 
     ParakeetEOU &model() { return model_; }
     const Tokenizer &tokenizer() const { return tokenizer_; }

--- a/include/parakeet/nemotron.hpp
+++ b/include/parakeet/nemotron.hpp
@@ -99,6 +99,10 @@ class NemotronTranscriber {
         partial_callback_ = std::move(cb);
     }
 
+    const std::vector<TimestampedToken> &get_timestamped_tokens() const {
+        return decode_state_.timestamped_tokens;
+    }
+
     ParakeetNemotron &model() { return model_; }
     const Tokenizer &tokenizer() const { return tokenizer_; }
 

--- a/include/parakeet/rnnt.hpp
+++ b/include/parakeet/rnnt.hpp
@@ -8,6 +8,7 @@
 #include "parakeet/config.hpp"
 #include "parakeet/encoder.hpp"
 #include "parakeet/lstm.hpp"
+#include "parakeet/timestamp.hpp"
 
 namespace parakeet {
 
@@ -88,5 +89,11 @@ std::vector<std::vector<int>> rnnt_greedy_decode(ParakeetRNNT &model,
                                                  const Tensor &encoder_out,
                                                  int blank_id = 1024,
                                                  int max_symbols_per_step = 10);
+
+// ─── Timestamped RNNT Greedy Decode ────────────────────────────────────────
+
+std::vector<std::vector<TimestampedToken>> rnnt_greedy_decode_with_timestamps(
+    ParakeetRNNT &model, const Tensor &encoder_out, int blank_id = 1024,
+    int max_symbols_per_step = 10);
 
 } // namespace parakeet

--- a/include/parakeet/timestamp.hpp
+++ b/include/parakeet/timestamp.hpp
@@ -10,14 +10,16 @@ namespace parakeet {
 
 struct TimestampedToken {
     int token_id;
-    int start_frame; // encoder frame index
-    int end_frame;   // encoder frame index (inclusive)
+    int start_frame;         // encoder frame index
+    int end_frame;           // encoder frame index (inclusive)
+    float confidence = 1.0f; // exp(log_prob), range [0, 1]
 };
 
 struct WordTimestamp {
     std::string word;
-    float start; // seconds
-    float end;   // seconds
+    float start;             // seconds
+    float end;               // seconds
+    float confidence = 1.0f; // min(token confidences), range [0, 1]
 };
 
 // ─── Frame ↔ Time Conversion ─────────────────────────────────────────────────

--- a/src/ctc.cpp
+++ b/src/ctc.cpp
@@ -1,5 +1,6 @@
 #include "parakeet/ctc.hpp"
 
+#include <cmath>
 #include <iostream>
 
 namespace parakeet {
@@ -109,7 +110,7 @@ ctc_greedy_decode_with_timestamps(const Tensor &log_probs, int blank_id) {
                 }
                 // If new token is non-blank, start a new span
                 if (best != blank_id) {
-                    tokens.push_back({best, t, t});
+                    tokens.push_back({best, t, t, std::exp(best_val)});
                 }
                 token_start_frame = t;
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,8 +149,8 @@ static int run_tdt_ctc_110m(const std::string &weights_path,
             std::cout << "\n--- Word Timestamps ---" << std::endl;
             for (const auto &w : words) {
                 std::cout << "  [" << std::fixed << std::setprecision(2)
-                          << w.start << "s - " << w.end << "s] " << w.word
-                          << std::endl;
+                          << w.start << "s - " << w.end << "s] ("
+                          << w.confidence << ") " << w.word << std::endl;
             }
         }
     }
@@ -229,8 +229,8 @@ static int run_tdt_600m(const std::string &weights_path,
             std::cout << "\n--- Word Timestamps ---" << std::endl;
             for (const auto &w : words) {
                 std::cout << "  [" << std::fixed << std::setprecision(2)
-                          << w.start << "s - " << w.end << "s] " << w.word
-                          << std::endl;
+                          << w.start << "s - " << w.end << "s] ("
+                          << w.confidence << ") " << w.word << std::endl;
             }
         }
     }
@@ -241,7 +241,8 @@ static int run_tdt_600m(const std::string &weights_path,
 
 static int run_rnnt_600m(const std::string &weights_path,
                          const std::string &audio_path,
-                         const std::string &vocab_path, bool use_gpu) {
+                         const std::string &vocab_path, bool use_gpu,
+                         bool show_timestamps) {
     using namespace parakeet;
     using Clock = std::chrono::high_resolution_clock;
 
@@ -277,8 +278,21 @@ static int run_rnnt_600m(const std::string &weights_path,
               << " ms" << std::endl;
 
     int blank_id = cfg.prediction.vocab_size - 1;
+
+    std::vector<std::vector<int>> token_ids;
+    std::vector<std::vector<TimestampedToken>> timestamped_tokens;
+
     t0 = Clock::now();
-    auto token_ids = rnnt_greedy_decode(model, encoder_out, blank_id);
+    if (show_timestamps) {
+        timestamped_tokens =
+            rnnt_greedy_decode_with_timestamps(model, encoder_out, blank_id);
+        token_ids.resize(timestamped_tokens.size());
+        for (size_t b = 0; b < timestamped_tokens.size(); ++b)
+            for (const auto &t : timestamped_tokens[b])
+                token_ids[b].push_back(t.token_id);
+    } else {
+        token_ids = rnnt_greedy_decode(model, encoder_out, blank_id);
+    }
     t1 = Clock::now();
     std::cout << "Decoder: RNNT ("
               << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0)
@@ -291,6 +305,17 @@ static int run_rnnt_600m(const std::string &weights_path,
         if (tokenizer.loaded()) {
             std::cout << tokenizer.decode(token_ids[b]) << std::endl;
         }
+        if (show_timestamps && b < timestamped_tokens.size() &&
+            tokenizer.loaded()) {
+            auto words =
+                group_timestamps(timestamped_tokens[b], tokenizer.pieces());
+            std::cout << "\n--- Word Timestamps ---" << std::endl;
+            for (const auto &w : words) {
+                std::cout << "  [" << std::fixed << std::setprecision(2)
+                          << w.start << "s - " << w.end << "s] ("
+                          << w.confidence << ") " << w.word << std::endl;
+            }
+        }
     }
     return 0;
 }
@@ -299,7 +324,8 @@ static int run_rnnt_600m(const std::string &weights_path,
 
 static int run_eou_streaming(const std::string &weights_path,
                              const std::string &audio_path,
-                             const std::string &vocab_path, bool use_gpu) {
+                             const std::string &vocab_path, bool use_gpu,
+                             bool show_timestamps) {
     using namespace parakeet;
     using Clock = std::chrono::high_resolution_clock;
 
@@ -339,6 +365,17 @@ static int run_eou_streaming(const std::string &weights_path,
               << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0)
                      .count()
               << " ms" << std::endl;
+
+    if (show_timestamps && transcriber.tokenizer().loaded()) {
+        auto words = group_timestamps(transcriber.get_timestamped_tokens(),
+                                      transcriber.tokenizer().pieces());
+        std::cout << "\n--- Word Timestamps ---" << std::endl;
+        for (const auto &w : words) {
+            std::cout << "  [" << std::fixed << std::setprecision(2) << w.start
+                      << "s - " << w.end << "s] (" << w.confidence << ") "
+                      << w.word << std::endl;
+        }
+    }
     return 0;
 }
 
@@ -347,7 +384,7 @@ static int run_eou_streaming(const std::string &weights_path,
 static int run_nemotron_streaming(const std::string &weights_path,
                                   const std::string &audio_path,
                                   const std::string &vocab_path, bool use_gpu,
-                                  int latency_frames) {
+                                  bool show_timestamps, int latency_frames) {
     using namespace parakeet;
     using Clock = std::chrono::high_resolution_clock;
 
@@ -383,6 +420,17 @@ static int run_nemotron_streaming(const std::string &weights_path,
               << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0)
                      .count()
               << " ms" << std::endl;
+
+    if (show_timestamps && transcriber.tokenizer().loaded()) {
+        auto words = group_timestamps(transcriber.get_timestamped_tokens(),
+                                      transcriber.tokenizer().pieces());
+        std::cout << "\n--- Word Timestamps ---" << std::endl;
+        for (const auto &w : words) {
+            std::cout << "  [" << std::fixed << std::setprecision(2) << w.start
+                      << "s - " << w.end << "s] (" << w.confidence << ") "
+                      << w.word << std::endl;
+        }
+    }
     return 0;
 }
 
@@ -491,13 +539,15 @@ int main(int argc, char *argv[]) {
             return run_tdt_600m(weights_path, audio_path, vocab_path, use_gpu,
                                 show_timestamps);
         } else if (model_type == "rnnt-600m") {
-            return run_rnnt_600m(weights_path, audio_path, vocab_path, use_gpu);
+            return run_rnnt_600m(weights_path, audio_path, vocab_path, use_gpu,
+                                 show_timestamps);
         } else if (model_type == "eou-120m") {
             return run_eou_streaming(weights_path, audio_path, vocab_path,
-                                     use_gpu);
+                                     use_gpu, show_timestamps);
         } else if (model_type == "nemotron-600m") {
             return run_nemotron_streaming(weights_path, audio_path, vocab_path,
-                                          use_gpu, latency_frames);
+                                          use_gpu, show_timestamps,
+                                          latency_frames);
         } else if (model_type == "sortformer") {
             return run_sortformer(weights_path, audio_path, use_gpu);
         } else {


### PR DESCRIPTION
## Confidence Scores

Per-token and per-word confidence scores for all decoder types.

### What

Surfaces the log-probabilities that decoders already compute (but discard after argmax) as confidence values in `[0, 1]`. Piggybacks on the existing `--timestamps` path — no new API parameters.

- **Token confidence**: `exp(max_log_prob)` at the frame where the token is emitted
- **Word confidence**: `min(token confidences)` across constituent tokens
- **Sentence confidence** (sentence timestamp mode): `min(word confidences)`

### Decoders

| Decoder | Timestamps | Confidence | Notes |
|---------|-----------|------------|-------|
| CTC | existing | **new** | Uses `best_val` already computed in manual argmax |
| TDT | existing | **new** | Replaced `ops::argmax` with manual argmax for index+value |
| RNNT | **new** | **new** | New `rnnt_greedy_decode_with_timestamps()` |
| Streaming (EOU/Nemotron) | **new** | **new** | Tracks absolute frame offset across chunks |
| Sortformer | n/a | n/a | Diarization, not ASR |

### Output

```
--- Word Timestamps ---
  [0.24s - 0.48s] (0.98) Well
  [0.48s - 0.56s] (0.95) I
  [0.56s - 0.96s] (0.87) don't
```

### Backward compatibility

Fully backward compatible. `confidence` fields default to `1.0f` — existing code that constructs `TimestampedToken{id, start, end}` or `WordTimestamp{word, start, end}` compiles unchanged.
