### PR TITLE
Add module_to_dtype and use for fp16 casting

### DIFF
--- a/include/parakeet/api/transcribe.hpp
+++ b/include/parakeet/api/transcribe.hpp
@@ -28,6 +28,13 @@ using namespace models;
 using namespace decode;
 using namespace audio;
 
+/// Cast all parameters of a module to the given dtype (in-place).
+inline void module_to_dtype(axiom::nn::Module &module, axiom::DType dtype) {
+    for (auto *p : module.parameters()) {
+        *p = p->astype(dtype);
+    }
+}
+
 // ─── Transcription Result ───────────────────────────────────────────────────
 
 struct TranscribeResult {
@@ -88,7 +95,7 @@ class Transcriber {
 
     /// Cast model to fp16. Call before to_gpu() for efficient transfer.
     void to_half() {
-        model_.to(axiom::DType::Float16);
+        module_to_dtype(model_, axiom::DType::Float16);
         use_fp16_ = true;
     }
 
@@ -515,7 +522,7 @@ class TDTTranscriber {
     }
 
     void to_half() {
-        model_.to(axiom::DType::Float16);
+        module_to_dtype(model_, axiom::DType::Float16);
         use_fp16_ = true;
     }
 
@@ -835,7 +842,7 @@ class StreamingTranscriber {
     }
 
     void to_half() {
-        model_.to(axiom::DType::Float16);
+        module_to_dtype(model_, axiom::DType::Float16);
         use_fp16_ = true;
     }
 
@@ -906,7 +913,7 @@ class NemotronTranscriber {
     }
 
     void to_half() {
-        model_.to(axiom::DType::Float16);
+        module_to_dtype(model_, axiom::DType::Float16);
         use_fp16_ = true;
     }
 

--- a/src/api/diarize.cpp
+++ b/src/api/diarize.cpp
@@ -69,7 +69,7 @@ void DiarizedTranscriber::to_gpu() {
 
 void DiarizedTranscriber::to_half() {
     transcriber_.to_half();
-    sortformer_.to(axiom::DType::Float16);
+    api::module_to_dtype(sortformer_, axiom::DType::Float16);
     use_fp16_ = true;
 }
 

--- a/src/audio/vad.cpp
+++ b/src/audio/vad.cpp
@@ -20,7 +20,8 @@ void SileroVAD::to_gpu() {
 }
 
 void SileroVAD::to_half() {
-    model_.to(axiom::DType::Float16);
+    for (auto *p : model_.parameters())
+        *p = p->astype(axiom::DType::Float16);
     use_fp16_ = true;
     initialized_ = false;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,7 +72,8 @@ static int run_tdt_ctc_110m(const std::string &weights_path,
     std::cout << "Model loaded (" << weights.size() << " tensors)" << std::endl;
 
     if (use_fp16) {
-        model.to(axiom::DType::Float16);
+        for (auto *p : model.parameters())
+            *p = p->astype(axiom::DType::Float16);
         std::cout << "Model cast to fp16" << std::endl;
     }
 
@@ -381,7 +382,8 @@ static int run_tdt_600m(
     std::cout << "Model loaded (" << weights.size() << " tensors)" << std::endl;
 
     if (use_fp16) {
-        model.to(axiom::DType::Float16);
+        for (auto *p : model.parameters())
+            *p = p->astype(axiom::DType::Float16);
         std::cout << "Model cast to fp16" << std::endl;
     }
 
@@ -610,7 +612,8 @@ static int run_rnnt_600m(const std::string &weights_path,
     std::cout << "Model loaded (" << weights.size() << " tensors)" << std::endl;
 
     if (use_fp16) {
-        model.to(axiom::DType::Float16);
+        for (auto *p : model.parameters())
+            *p = p->astype(axiom::DType::Float16);
         std::cout << "Model cast to fp16" << std::endl;
     }
 
@@ -821,7 +824,8 @@ static int run_sortformer(const std::string &weights_path,
     model.load_state_dict(weights, "", false);
 
     if (use_fp16) {
-        model.to(axiom::DType::Float16);
+        for (auto *p : model.parameters())
+            *p = p->astype(axiom::DType::Float16);
         std::cout << "Model cast to fp16" << std::endl;
     }
 


### PR DESCRIPTION
Introduce api::module_to_dtype helper (include/parakeet/api/transcribe.hpp) to cast all module parameters to a given dtype in-place. Replace previous model.to(...) calls with the new helper or equivalent per-parameter loops in multiple places (transcribe classes, diarize, VAD, and main) to ensure parameters are explicitly converted to Float16 when use_fp16 is enabled. Also update third_party/axiom submodule pointer.