### PR TITLE
Cache ARPA LM

### DIFF
--- a/examples/server/main.cpp
+++ b/examples/server/main.cpp
@@ -25,7 +25,6 @@
 #include <sstream>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <vector>
 
 #include <sys/socket.h>
@@ -430,28 +429,9 @@ struct WarmTranscriber final : ServerTranscriber {
 
 struct WarmTDT600Transcriber final : ServerTranscriber {
     explicit WarmTDT600Transcriber(const ServerConfig &config)
-        : model_config(parakeet::make_tdt_600m_config()), model(model_config) {
-        auto weights = axiom::io::safetensors::load(config.weights_path);
-        model.load_state_dict(weights, "", false);
-        tokenizer.load(config.vocab_path);
-
-        if (config.use_fp16) {
-            model.to(axiom::DType::Float16);
-            use_fp16 = true;
-        }
-        if (config.use_gpu) {
-            model.to(axiom::Device::GPU);
-            use_gpu = true;
-        }
-        if (!config.vad_path.empty()) {
-            vad = std::make_unique<parakeet::audio::SileroVAD>(config.vad_path);
-            if (use_fp16) {
-                vad->to_half();
-            }
-            if (use_gpu) {
-                vad->to_gpu();
-            }
-        }
+        : transcriber(config.weights_path, config.vocab_path,
+                      parakeet::make_tdt_600m_config()) {
+        configure_transcriber(transcriber, config);
     }
 
     parakeet::TranscribeResult transcribe(const Request &request) override {
@@ -459,141 +439,11 @@ struct WarmTDT600Transcriber final : ServerTranscriber {
             throw std::runtime_error("tdt-600m server only supports "
                                      "decoder=\"tdt\" or \"tdt-beam\"");
         }
-
-        auto audio_data = parakeet::read_audio(request.audio_path);
-        auto options = make_options(request);
-
-        axiom::Tensor audio_for_asr = audio_data.samples;
-        std::unique_ptr<parakeet::audio::TimestampRemapper> remapper;
-        if (options.use_vad && vad) {
-            auto segments = vad->detect(audio_data.samples);
-            if (!segments.empty()) {
-                audio_for_asr = parakeet::audio::collect_speech(
-                    audio_data.samples, segments);
-                if (options.timestamps) {
-                    remapper =
-                        std::make_unique<parakeet::audio::TimestampRemapper>(
-                            segments);
-                }
-            }
-        }
-
-        parakeet::AudioConfig audio_cfg;
-        audio_cfg.n_mels = model_config.encoder.mel_bins;
-        auto features = parakeet::preprocess_audio(audio_for_asr, audio_cfg);
-        if (use_fp16) {
-            features = features.half();
-        }
-        if (use_gpu) {
-            features = features.gpu();
-        }
-
-        auto encoder_out = model.encoder()(features);
-
-        parakeet::ContextTrie trie;
-        const bool use_boost =
-            !options.boost_phrases.empty() && tokenizer.loaded();
-        if (use_boost) {
-            trie.build(options.boost_phrases, tokenizer);
-        }
-
-        const parakeet::ArpaLM *lm = nullptr;
-        if (options.decoder == parakeet::Decoder::TDT_BEAM &&
-            !options.lm_path.empty()) {
-            lm = &get_or_load_lm(options.lm_path);
-        }
-
-        const int blank_id = model_config.prediction.vocab_size - 1;
-        parakeet::TranscribeResult result;
-
-        if (options.timestamps) {
-            std::vector<std::vector<parakeet::TimestampedToken>> all_tokens;
-            if (options.decoder == parakeet::Decoder::TDT_BEAM) {
-                parakeet::TDTBeamSearchOptions beam_options;
-                beam_options.beam_width = options.beam_width;
-                beam_options.blank_id = blank_id;
-                beam_options.lm = lm;
-                beam_options.lm_weight = options.lm_weight;
-                beam_options.pieces =
-                    tokenizer.loaded() ? &tokenizer.pieces() : nullptr;
-                all_tokens = parakeet::tdt_beam_decode_with_timestamps(
-                    model, encoder_out, model_config.durations, beam_options);
-            } else {
-                all_tokens =
-                    use_boost
-                        ? parakeet::tdt_greedy_decode_with_timestamps_boosted(
-                              model, encoder_out, model_config.durations, trie,
-                              options.boost_score, blank_id)
-                        : parakeet::tdt_greedy_decode_with_timestamps(
-                              model, encoder_out, model_config.durations,
-                              blank_id);
-            }
-
-            if (!all_tokens.empty()) {
-                result.timestamped_tokens = all_tokens[0];
-                if (remapper) {
-                    result.timestamped_tokens =
-                        remapper->remap_tokens(result.timestamped_tokens);
-                }
-                for (const auto &token : result.timestamped_tokens) {
-                    result.token_ids.push_back(token.token_id);
-                }
-                result.text = tokenizer.decode(result.token_ids);
-                result.word_timestamps = parakeet::group_timestamps(
-                    result.timestamped_tokens, tokenizer.pieces());
-            }
-            return result;
-        }
-
-        std::vector<std::vector<int>> all_tokens;
-        if (options.decoder == parakeet::Decoder::TDT_BEAM) {
-            parakeet::TDTBeamSearchOptions beam_options;
-            beam_options.beam_width = options.beam_width;
-            beam_options.blank_id = blank_id;
-            beam_options.lm = lm;
-            beam_options.lm_weight = options.lm_weight;
-            beam_options.pieces =
-                tokenizer.loaded() ? &tokenizer.pieces() : nullptr;
-            all_tokens = parakeet::tdt_beam_decode(
-                model, encoder_out, model_config.durations, beam_options);
-        } else {
-            all_tokens =
-                use_boost ? parakeet::tdt_greedy_decode_boosted(
-                                model, encoder_out, model_config.durations,
-                                trie, options.boost_score, blank_id)
-                          : parakeet::tdt_greedy_decode(model, encoder_out,
-                                                        model_config.durations,
-                                                        blank_id);
-        }
-
-        if (!all_tokens.empty()) {
-            result.token_ids = all_tokens[0];
-            result.text = tokenizer.decode(result.token_ids);
-        }
-        return result;
+        return transcriber.transcribe(request.audio_path,
+                                      make_options(request));
     }
 
-    // Cache ARPA language models by path so the warm process does not reload
-    // them on every request. The server is single-threaded, so no locking.
-    const parakeet::ArpaLM &get_or_load_lm(const std::string &path) {
-        auto it = lm_cache.find(path);
-        if (it != lm_cache.end()) {
-            return it->second;
-        }
-        std::cerr << "loading LM from " << path << "\n";
-        parakeet::ArpaLM lm;
-        lm.load(path);
-        auto inserted = lm_cache.emplace(path, std::move(lm)).first;
-        return inserted->second;
-    }
-
-    parakeet::TDTConfig model_config;
-    parakeet::ParakeetTDT model;
-    parakeet::Tokenizer tokenizer;
-    bool use_gpu = false;
-    bool use_fp16 = false;
-    std::unique_ptr<parakeet::audio::SileroVAD> vad;
-    std::unordered_map<std::string, parakeet::ArpaLM> lm_cache;
+    parakeet::TDTTranscriber transcriber;
 };
 
 std::unique_ptr<ServerTranscriber>

--- a/include/parakeet/api/transcribe.hpp
+++ b/include/parakeet/api/transcribe.hpp
@@ -597,12 +597,14 @@ class TDTTranscriber {
             lm = &get_or_load_lm(opts.lm_path);
         }
 
+        int blank_id = config_.prediction.vocab_size - 1;
         TranscribeResult result;
 
         if (opts.timestamps) {
             if (opts.decoder == Decoder::TDT_BEAM) {
                 TDTBeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
+                bs_opts.blank_id = blank_id;
                 bs_opts.lm = lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
@@ -619,9 +621,10 @@ class TDTTranscriber {
                 auto all_ts = use_boost
                                   ? tdt_greedy_decode_with_timestamps_boosted(
                                         model_, encoder_out, config_.durations,
-                                        trie, opts.boost_score)
+                                        trie, opts.boost_score, blank_id)
                                   : tdt_greedy_decode_with_timestamps(
-                                        model_, encoder_out, config_.durations);
+                                        model_, encoder_out, config_.durations,
+                                        blank_id);
                 if (!all_ts.empty()) {
                     result.timestamped_tokens = all_ts[0];
                     for (const auto &t : result.timestamped_tokens) {
@@ -644,6 +647,7 @@ class TDTTranscriber {
             if (opts.decoder == Decoder::TDT_BEAM) {
                 TDTBeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
+                bs_opts.blank_id = blank_id;
                 bs_opts.lm = lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
@@ -658,12 +662,11 @@ class TDTTranscriber {
                 }
             } else {
                 auto all_tokens =
-                    use_boost
-                        ? tdt_greedy_decode_boosted(model_, encoder_out,
-                                                    config_.durations, trie,
-                                                    opts.boost_score)
-                        : tdt_greedy_decode(model_, encoder_out,
-                                            config_.durations);
+                    use_boost ? tdt_greedy_decode_boosted(
+                                    model_, encoder_out, config_.durations,
+                                    trie, opts.boost_score, blank_id)
+                              : tdt_greedy_decode(model_, encoder_out,
+                                                  config_.durations, blank_id);
                 if (!all_tokens.empty()) {
                     result.token_ids = all_tokens[0];
                     if (tokenizer_.loaded()) {

--- a/include/parakeet/api/transcribe.hpp
+++ b/include/parakeet/api/transcribe.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <axiom/axiom.hpp>
@@ -153,12 +154,12 @@ class Transcriber {
             trie.build(opts.boost_phrases, tokenizer_);
         }
 
-        // Load LM if beam search with LM requested
-        ArpaLM lm;
+        // Look up LM in cache if beam search with LM requested.
+        const ArpaLM *lm = nullptr;
         if ((opts.decoder == Decoder::CTC_BEAM ||
              opts.decoder == Decoder::TDT_BEAM) &&
             !opts.lm_path.empty()) {
-            lm.load(opts.lm_path);
+            lm = &get_or_load_lm(opts.lm_path);
         }
 
         TranscribeResult result;
@@ -167,7 +168,7 @@ class Transcriber {
             if (opts.decoder == Decoder::TDT_BEAM) {
                 TDTBeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
-                bs_opts.lm = lm.loaded() ? &lm : nullptr;
+                bs_opts.lm = lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
                     tokenizer_.loaded() ? &tokenizer_.pieces() : nullptr;
@@ -184,7 +185,7 @@ class Transcriber {
                 auto cpu_lp = log_probs.cpu();
                 BeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
-                bs_opts.lm = lm.loaded() ? &lm : nullptr;
+                bs_opts.lm = lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
                     tokenizer_.loaded() ? &tokenizer_.pieces() : nullptr;
@@ -239,7 +240,7 @@ class Transcriber {
             if (opts.decoder == Decoder::TDT_BEAM) {
                 TDTBeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
-                bs_opts.lm = lm.loaded() ? &lm : nullptr;
+                bs_opts.lm = lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
                     tokenizer_.loaded() ? &tokenizer_.pieces() : nullptr;
@@ -250,7 +251,7 @@ class Transcriber {
                 auto cpu_lp = log_probs.cpu();
                 BeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
-                bs_opts.lm = lm.loaded() ? &lm : nullptr;
+                bs_opts.lm = lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
                     tokenizer_.loaded() ? &tokenizer_.pieces() : nullptr;
@@ -339,12 +340,12 @@ class Transcriber {
             trie.build(opts.boost_phrases, tokenizer_);
         }
 
-        // Load LM if beam search with LM requested
-        ArpaLM batch_lm;
+        // Look up LM in cache if beam search with LM requested.
+        const ArpaLM *batch_lm = nullptr;
         if ((opts.decoder == Decoder::CTC_BEAM ||
              opts.decoder == Decoder::TDT_BEAM) &&
             !opts.lm_path.empty()) {
-            batch_lm.load(opts.lm_path);
+            batch_lm = &get_or_load_lm(opts.lm_path);
         }
 
         std::vector<TranscribeResult> results(samples.size());
@@ -353,7 +354,7 @@ class Transcriber {
             if (opts.decoder == Decoder::TDT_BEAM) {
                 TDTBeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
-                bs_opts.lm = batch_lm.loaded() ? &batch_lm : nullptr;
+                bs_opts.lm = batch_lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
                     tokenizer_.loaded() ? &tokenizer_.pieces() : nullptr;
@@ -370,7 +371,7 @@ class Transcriber {
                 auto cpu_lp = log_probs.cpu();
                 BeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
-                bs_opts.lm = batch_lm.loaded() ? &batch_lm : nullptr;
+                bs_opts.lm = batch_lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
                     tokenizer_.loaded() ? &tokenizer_.pieces() : nullptr;
@@ -422,7 +423,7 @@ class Transcriber {
             if (opts.decoder == Decoder::TDT_BEAM) {
                 TDTBeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
-                bs_opts.lm = batch_lm.loaded() ? &batch_lm : nullptr;
+                bs_opts.lm = batch_lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
                     tokenizer_.loaded() ? &tokenizer_.pieces() : nullptr;
@@ -434,7 +435,7 @@ class Transcriber {
                 auto cpu_lp = log_probs.cpu();
                 BeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
-                bs_opts.lm = batch_lm.loaded() ? &batch_lm : nullptr;
+                bs_opts.lm = batch_lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
                     tokenizer_.loaded() ? &tokenizer_.pieces() : nullptr;
@@ -481,13 +482,30 @@ class Transcriber {
     ParakeetTDTCTC &model() { return model_; }
     const Tokenizer &tokenizer() const { return tokenizer_; }
 
+    /// Drop any cached ARPA language models. Useful if a path's contents
+    /// changed on disk or to reclaim memory.
+    void clear_lm_cache() { lm_cache_.clear(); }
+
   private:
+    // Cache ARPA language models by path so repeated transcribe() calls do
+    // not pay the full ARPA load cost every time. Not thread-safe — wrap
+    // externally if calling transcribe() concurrently from multiple threads.
+    const ArpaLM &get_or_load_lm(const std::string &path) {
+        auto it = lm_cache_.find(path);
+        if (it != lm_cache_.end())
+            return it->second;
+        ArpaLM lm;
+        lm.load(path);
+        return lm_cache_.emplace(path, std::move(lm)).first->second;
+    }
+
     TDTCTCConfig config_;
     ParakeetTDTCTC model_;
     Tokenizer tokenizer_;
     bool use_gpu_ = false;
     bool use_fp16_ = false;
     std::unique_ptr<audio::SileroVAD> vad_;
+    std::unordered_map<std::string, ArpaLM> lm_cache_;
 };
 
 // ─── TDT-Only Transcriber (for 600M multilingual etc.) ─────────────────────
@@ -573,10 +591,10 @@ class TDTTranscriber {
             trie.build(opts.boost_phrases, tokenizer_);
         }
 
-        // Load LM if beam search with LM requested
-        ArpaLM lm;
+        // Look up LM in cache if beam search with LM requested.
+        const ArpaLM *lm = nullptr;
         if (opts.decoder == Decoder::TDT_BEAM && !opts.lm_path.empty()) {
-            lm.load(opts.lm_path);
+            lm = &get_or_load_lm(opts.lm_path);
         }
 
         TranscribeResult result;
@@ -585,7 +603,7 @@ class TDTTranscriber {
             if (opts.decoder == Decoder::TDT_BEAM) {
                 TDTBeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
-                bs_opts.lm = lm.loaded() ? &lm : nullptr;
+                bs_opts.lm = lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
                     tokenizer_.loaded() ? &tokenizer_.pieces() : nullptr;
@@ -626,7 +644,7 @@ class TDTTranscriber {
             if (opts.decoder == Decoder::TDT_BEAM) {
                 TDTBeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
-                bs_opts.lm = lm.loaded() ? &lm : nullptr;
+                bs_opts.lm = lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
                     tokenizer_.loaded() ? &tokenizer_.pieces() : nullptr;
@@ -715,10 +733,10 @@ class TDTTranscriber {
             trie.build(opts.boost_phrases, tokenizer_);
         }
 
-        // Load LM if beam search with LM requested
-        ArpaLM batch_lm;
+        // Look up LM in cache if beam search with LM requested.
+        const ArpaLM *batch_lm = nullptr;
         if (opts.decoder == Decoder::TDT_BEAM && !opts.lm_path.empty()) {
-            batch_lm.load(opts.lm_path);
+            batch_lm = &get_or_load_lm(opts.lm_path);
         }
 
         int blank_id = config_.prediction.vocab_size - 1;
@@ -729,7 +747,7 @@ class TDTTranscriber {
                 TDTBeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
                 bs_opts.blank_id = blank_id;
-                bs_opts.lm = batch_lm.loaded() ? &batch_lm : nullptr;
+                bs_opts.lm = batch_lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
                     tokenizer_.loaded() ? &tokenizer_.pieces() : nullptr;
@@ -769,7 +787,7 @@ class TDTTranscriber {
                 TDTBeamSearchOptions bs_opts;
                 bs_opts.beam_width = opts.beam_width;
                 bs_opts.blank_id = blank_id;
-                bs_opts.lm = batch_lm.loaded() ? &batch_lm : nullptr;
+                bs_opts.lm = batch_lm;
                 bs_opts.lm_weight = opts.lm_weight;
                 bs_opts.pieces =
                     tokenizer_.loaded() ? &tokenizer_.pieces() : nullptr;
@@ -809,13 +827,30 @@ class TDTTranscriber {
     ParakeetTDT &model() { return model_; }
     const Tokenizer &tokenizer() const { return tokenizer_; }
 
+    /// Drop any cached ARPA language models. Useful if a path's contents
+    /// changed on disk or to reclaim memory.
+    void clear_lm_cache() { lm_cache_.clear(); }
+
   private:
+    // Cache ARPA language models by path so repeated transcribe() calls do
+    // not pay the full ARPA load cost every time. Not thread-safe — wrap
+    // externally if calling transcribe() concurrently from multiple threads.
+    const ArpaLM &get_or_load_lm(const std::string &path) {
+        auto it = lm_cache_.find(path);
+        if (it != lm_cache_.end())
+            return it->second;
+        ArpaLM lm;
+        lm.load(path);
+        return lm_cache_.emplace(path, std::move(lm)).first->second;
+    }
+
     TDTConfig config_;
     ParakeetTDT model_;
     Tokenizer tokenizer_;
     bool use_gpu_ = false;
     bool use_fp16_ = false;
     std::unique_ptr<audio::SileroVAD> vad_;
+    std::unordered_map<std::string, ArpaLM> lm_cache_;
 };
 
 // ─── Streaming Transcriber ───────────────────────────────────────────────────


### PR DESCRIPTION
# Cache ARPA LM in `Transcriber` / `TDTTranscriber`

Closes #20.

## Problem

`Transcriber` and `TDTTranscriber` reloaded the ARPA LM from disk on every `transcribe()` / `transcribe_batch()` call. Long-lived consumers (e.g. the warm-server example's `WarmTranscriber` path) silently paid the full ARPA load cost on every request. PR #19 fixed this in the example for the tdt-600m path only; the underlying library classes still had the issue.

## Fix

Each transcriber now owns an `unordered_map<string, ArpaLM>` keyed by path, populated by a private `get_or_load_lm()` helper. Beam-search options receive a `const ArpaLM*` from the cache instead of a freshly-loaded stack-local. A public `clear_lm_cache()` is exposed for callers that want to reclaim memory or pick up on-disk changes.

Documented as **not thread-safe**, consistent with the rest of these classes (model state is also unguarded). Concurrent callers must wrap externally.

## Bonus: latent `blank_id` bug fixed in `TDTTranscriber::transcribe`

While verifying the example simplification below, I noticed
`TDTTranscriber::transcribe` (single-file path) never set `blank_id` on its decoder calls, it relied on the decoder default of `1024`. That default is correct for tdt-ctc-110m (vocab=1025) but wrong for tdt-600m (vocab=8193, blank=8192). The `transcribe_batch` sibling already computed `config_.prediction.vocab_size - 1` correctly; the single-file path now does the same.

The bug was masked in practice because the warm-server example bypassed `TDTTranscriber` entirely with a hand-rolled `WarmTDT600Transcriber` that set `blank_id` explicitly.

## Bonus: `examples/server` simplification

With the LM cache and `blank_id` fix in the library, the hand-rolled `WarmTDT600Transcriber` collapses to a thin wrapper over `parakeet::TDTTranscriber`, mirroring the existing `WarmTranscriber`.

## Verification

- `make build` and `make build SERVER=ON` clean.
- All 131 tests in `parakeet_tests` pass.

## Out of scope (follow-up worth filing)

`Transcriber` (the TDT-CTC class) has the same shape of latent `blank_id` fragility, every decoder call uses the `1024` default or a hardcoded literal instead of deriving from `config_.prediction.vocab_size - 1` / `config_.ctc_vocab_size - 1`. It doesn't fire today because `make_110m_config()` is the only `TDTCTCConfig` in tree and happens to have vocab=1025. Worth a separate PR ("derive `blank_id` from config, not 1024").
