### PR TITLE
Release pipeline for v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g. v0.1.0-rc1). Used for artifact names; no GitHub release is created on manual runs.'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            os: macos
+            arch: arm64
+          - runner: macos-13
+            os: macos
+            arch: x86_64
+          - runner: ubuntu-22.04
+            os: linux
+            arch: x86_64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          if [[ -n "${{ github.event.inputs.version }}" ]]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install macOS deps
+        if: startsWith(matrix.runner, 'macos')
+        run: brew install ninja libomp
+
+      - name: Install Linux deps
+        if: matrix.runner == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build patchelf libopenblas-dev
+
+      - name: Package
+        run: scripts/package_release.sh --version ${{ steps.version.outputs.version }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: parakeet-${{ steps.version.outputs.version }}-${{ matrix.os }}-${{ matrix.arch }}
+          path: dist/parakeet-${{ steps.version.outputs.version }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+          if-no-files-found: error
+
+  release:
+    needs: package
+    runs-on: ubuntu-22.04
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*.tar.gz
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ plan.md
 *.dylib
 *.dll
 *.lib
+build-release/
+dist/
 
 # Coverage
 *.gcno

--- a/README.md
+++ b/README.md
@@ -49,7 +49,21 @@ std::cout << result.text << std::endl;
 
 See [examples/](examples/) for code demonstrating each feature.
 
-## Build
+## Install
+
+Prebuilt binaries are attached to each [GitHub release](https://github.com/Frikallo/parakeet.cpp/releases) for macOS arm64, macOS x86_64, and Linux x86_64. Download the tarball for your platform and extract:
+
+```bash
+tar -xzf parakeet-v0.1.0-macos-arm64.tar.gz
+cd parakeet-v0.1.0-macos-arm64
+# On macOS, clear the Gatekeeper quarantine attribute first:
+xattr -dr com.apple.quarantine .
+./bin/parakeet --help
+```
+
+The archive ships a self-contained `bin/parakeet` (and `bin/example-server`) plus `lib/libaxiom` with `@rpath`/`$ORIGIN` set so the binaries resolve their dependencies relative to the install dir — drop the directory anywhere. The C-API headers under `include/parakeet/` are included for embedders.
+
+## Build from source
 
 ```bash
 git clone --recursive https://github.com/frikallo/parakeet.cpp
@@ -59,6 +73,8 @@ make test
 ```
 
 Requirements: C++20 (Clang 14+ or GCC 12+), CMake 3.20+, macOS 13+ for Metal GPU.
+
+> **macOS:** building requires the **full Xcode** install (not just Command Line Tools), because axiom compiles its Metal shaders with `xcrun metal` and `xcrun metallib` — those ship only with Xcode. If you just want to run parakeet, use the prebuilt tarball above; the `.metallib` is embedded into the shipped `libaxiom.dylib` and runs without any Xcode/CLT install on the user side.
 
 ## Convert Weights
 

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Build parakeet.cpp in distribution mode and stage a release tarball.
+#
+# Usage:
+#   scripts/package_release.sh --version v0.1.0
+#   scripts/package_release.sh --version v0.1.0 --build-dir build-release
+#
+# Output: dist/parakeet-<version>-<os>-<arch>.tar.gz
+#
+# Used by .github/workflows/release.yml. Designed to be runnable locally so
+# rpath/packaging changes can be validated before pushing a tag.
+
+set -euo pipefail
+
+VERSION=""
+BUILD_DIR="build-release"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version) VERSION="$2"; shift 2 ;;
+        --build-dir) BUILD_DIR="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,11p' "$0"
+            exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$VERSION" ]]; then
+    echo "error: --version is required (e.g. v0.1.0)" >&2
+    exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ─── Platform slug ──────────────────────────────────────────────────────────
+case "$(uname -s)" in
+    Darwin)  OS="macos" ;;
+    Linux)   OS="linux" ;;
+    *) echo "error: unsupported OS $(uname -s)" >&2; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+    arm64|aarch64) ARCH="arm64" ;;
+    x86_64)        ARCH="x86_64" ;;
+    *) echo "error: unsupported arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+SLUG="parakeet-${VERSION}-${OS}-${ARCH}"
+STAGE_DIR="dist/${SLUG}"
+TARBALL="dist/${SLUG}.tar.gz"
+
+echo "==> Building ${SLUG}"
+
+# ─── Configure + build ──────────────────────────────────────────────────────
+# Dist mode statically links libomp/libgomp into libaxiom and OpenBLAS on Linux,
+# leaving only system frameworks (Accelerate, Metal) as runtime deps on macOS.
+cmake -S . -B "$BUILD_DIR" \
+    -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DAXIOM_DIST_BUILD=ON \
+    -DPARAKEET_BUILD_CLI=ON \
+    -DPARAKEET_BUILD_TESTS=OFF \
+    -DPARAKEET_BUILD_EXAMPLES=ON \
+    -DPARAKEET_BUILD_SERVER_EXAMPLE=ON
+
+cmake --build "$BUILD_DIR" -j
+
+# ─── Stage layout ───────────────────────────────────────────────────────────
+echo "==> Staging ${STAGE_DIR}"
+rm -rf "$STAGE_DIR"
+mkdir -p "$STAGE_DIR"/{bin,lib,include}
+
+cp "$BUILD_DIR/parakeet"                       "$STAGE_DIR/bin/"
+cp "$BUILD_DIR/examples/server/example-server" "$STAGE_DIR/bin/"
+
+# Copy libaxiom + symlinks (-a preserves symlinks, perms, timestamps).
+if [[ "$OS" == "macos" ]]; then
+    cp -a "$BUILD_DIR/third_party/axiom/"libaxiom.*.dylib "$STAGE_DIR/lib/"
+    cp -a "$BUILD_DIR/third_party/axiom/"libaxiom.dylib   "$STAGE_DIR/lib/"
+else
+    cp -a "$BUILD_DIR/third_party/axiom/"libaxiom.so*     "$STAGE_DIR/lib/"
+fi
+
+cp -a include/parakeet "$STAGE_DIR/include/"
+cp LICENSE README.md   "$STAGE_DIR/"
+
+# ─── Fix rpaths ─────────────────────────────────────────────────────────────
+# Make binaries find bundled libaxiom relative to their own location, so the
+# tarball is fully relocatable.
+echo "==> Fixing rpaths"
+
+fix_rpath_macos() {
+    local bin="$1"
+    # Strip any build-dir rpaths that snuck in (cmake adds them by default).
+    local rpaths
+    rpaths=$(otool -l "$bin" | awk '/LC_RPATH/{f=1;next} f && /path /{print $2; f=0}')
+    while IFS= read -r rp; do
+        [[ -z "$rp" ]] && continue
+        install_name_tool -delete_rpath "$rp" "$bin" 2>/dev/null || true
+    done <<< "$rpaths"
+    install_name_tool -add_rpath "@loader_path/../lib" "$bin"
+}
+
+fix_rpath_linux() {
+    local bin="$1"
+    patchelf --set-rpath '$ORIGIN/../lib' "$bin"
+}
+
+for bin in "$STAGE_DIR/bin/"*; do
+    if [[ "$OS" == "macos" ]]; then
+        fix_rpath_macos "$bin"
+    else
+        fix_rpath_linux "$bin"
+    fi
+done
+
+# ─── Verify no leaked host paths ────────────────────────────────────────────
+echo "==> Verifying"
+LEAK=0
+for bin in "$STAGE_DIR/bin/"*; do
+    if [[ "$OS" == "macos" ]]; then
+        if otool -L "$bin" | grep -E "/opt/homebrew|/usr/local/Cellar|$REPO_ROOT" >&2; then
+            echo "error: $bin references a host path above" >&2
+            LEAK=1
+        fi
+    else
+        if ldd "$bin" 2>/dev/null | grep -E "$REPO_ROOT|/home/" >&2; then
+            echo "error: $bin references a host path above" >&2
+            LEAK=1
+        fi
+    fi
+done
+if [[ "$LEAK" -ne 0 ]]; then
+    exit 1
+fi
+
+# ─── Tarball ────────────────────────────────────────────────────────────────
+echo "==> Creating ${TARBALL}"
+tar -czf "$TARBALL" -C dist "$SLUG"
+
+if command -v shasum >/dev/null; then
+    shasum -a 256 "$TARBALL"
+else
+    sha256sum "$TARBALL"
+fi
+
+echo "==> Done: ${TARBALL}"


### PR DESCRIPTION
# Release pipeline for v0.1.0

Closes #21 (the prebuilt-binaries + Xcode/CLT-doc parts).

## What this adds

- **`scripts/package_release.sh`** — local-first packaging script. Configures with `AXIOM_DIST_BUILD=ON` (which statically links libomp/libgomp/OpenBLAS into libaxiom), builds, stages a `bin/` + `lib/` + `include/` tree, fixes rpaths (`install_name_tool` on macOS, `patchelf` on Linux), and refuses to ship if `otool -L`/`ldd` shows a host-path leak. Designed to be runnable on a developer machine so packaging changes can be validated before pushing tags.
- **`.github/workflows/release.yml`** — matrix workflow (macos-14 / macos-13 / ubuntu-22.04). Each job calls the script. A final job creates the GitHub release and attaches all three tarballs. Triggers on `v*` tag push, plus `workflow_dispatch` for manual test runs (no release created on dispatch).
- **README** — new "Install" section pointing at releases with the `xattr -dr com.apple.quarantine` recipe; "Build from source" gains the one-line note that macOS source builds need full Xcode (not just CLT) because of `xcrun metal` / `xcrun metallib`. That covers ask (3) from the issue.
- **`.gitignore`** — adds `build-release/` and `dist/` (script outputs, never committed).

## Tarball layout

```
parakeet-v0.1.0-<os>-<arch>/
├── bin/
│   ├── parakeet
│   └── example-server
├── lib/
│   ├── libaxiom.<ver>.{dylib,so}
├── include/parakeet/...
├── README.md
└── LICENSE
```

Runtime deps after dist build:
- macOS: Metal, Foundation, MPS, MPSGraph, libc++, libSystem (all system).
- Linux: libstdc++, libc, libpthread (all system).

The Metal `.metallib` is embedded into `libaxiom.dylib` via axiom's existing `AXIOM_EMBED_METAL_LIBRARY=ON`. Runtime uses `newLibraryWithData:`, which is part of the macOS Metal framework — **no Xcode or CLT required on the user side**.

## What was validated locally (macos-arm64)

- Script ran clean.
- Tarball extracted to `/tmp` runs `bin/parakeet --help` (exit 0).
- `otool -L` shows no `/opt/homebrew` paths and no repo-absolute paths; `@rpath/libaxiom.0.dylib` resolves via the bundled lib.
- End-to-end: real model + real audio with `--gpu` produced the expected transcript ("Well, I don't wish to see it any more, observed Phoebe..."), encoder ran in 11ms — embedded `.metallib` worked through `newLibraryWithData:` from the relocated tarball.